### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+remaster-iso (0.9.3-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 07 May 2020 01:50:20 +0000
+
 remaster-iso (0.9.3-1) unstable; urgency=medium
 
   [ Richard Nelson ]

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/unixabg/remaster-iso/issues
+Bug-Submit: https://github.com/unixabg/remaster-iso/issues/new
+Repository: https://github.com/unixabg/remaster-iso.git
+Repository-Browse: https://github.com/unixabg/remaster-iso


### PR DESCRIPTION
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/remaster-iso/a6afd59b-0740-4c3b-aa73-2522f2ea5a2e.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/a6afd59b-0740-4c3b-aa73-2522f2ea5a2e/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a6afd59b-0740-4c3b-aa73-2522f2ea5a2e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a6afd59b-0740-4c3b-aa73-2522f2ea5a2e/diffoscope)).
